### PR TITLE
gate the forced 31db attenuation

### DIFF
--- a/Project Files/Source/ChannelMaster/networkproto1.c
+++ b/Project Files/Source/ChannelMaster/networkproto1.c
@@ -599,17 +599,17 @@ void WriteMainLoop(char* bufp)
 
 		case 12: // Step ATT control
 			C0 |= 0x16; //C0 0001 011x
-			//if (XmitBit)
-			//	//This is existing code. It used to apply 31dB attenuation to any receiver that is using ADC[1] (adc2 in the setup form) when in a TX state (XmitBit set)
-			//	//Unsure why this was forced, as it is not for oher adc's
-			//	C1 = 0x1F;
-			//else
-			//{
+			if (XmitBit && HPSDRModel != HPSDRModel_REDPITAYA)
+				//This is existing code. It used to apply 31dB attenuation to any receiver that is using ADC[1] (adc2 in the setup form) when in a TX state (XmitBit set)
+				//Unsure why this was forced, as it is not for oher adc's, however it has been left 'as is' for all radios other than the Red Pitaya
+				C1 = 0x1F;
+			else
+			{
 				if (HPSDRModel == HPSDRModel_REDPITAYA) //[2.10.3.9]DH1KLM  //model needed as board type (prn->discovery.BoardType) is an OrionII
 					C1 = (prn->adc[1].rx_step_attn & 0b00011111); //truncate the lower 5 bits, allowing a max value of 31
 				else
 					C1 = (prn->adc[1].rx_step_attn);
-			//}
+			}
 			C1 |= 0b00100000; //this enables the rx attenuation
 			C2 = (prn->adc[2].rx_step_attn & 0b00011111) | 0b00100000 |
 				((prn->cw.rev_paddle & 1) << 6);


### PR DESCRIPTION
When any RX is used that uses adc[1] (setup form shown as adc2) and transmission occurs, a 31 dB attenuation is applied to ADC[1] as per legacy code. This attenuation is only bypassed when using a Red Pitaya.